### PR TITLE
Feature  access token refreshing

### DIFF
--- a/src/main/java/net/crusadergames/bugwars/advice/AuthControllerAdvice.java
+++ b/src/main/java/net/crusadergames/bugwars/advice/AuthControllerAdvice.java
@@ -1,0 +1,23 @@
+package net.crusadergames.bugwars.advice;
+
+import net.crusadergames.bugwars.exception.TokenRefreshException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Date;
+
+@RestControllerAdvice
+public class AuthControllerAdvice {
+    @ExceptionHandler(value = TokenRefreshException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ErrorMessage handleTokenRefreshException(TokenRefreshException ex, WebRequest request) {
+        return new ErrorMessage(
+                HttpStatus.FORBIDDEN.value(),
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
+    }
+}

--- a/src/main/java/net/crusadergames/bugwars/advice/ErrorMessage.java
+++ b/src/main/java/net/crusadergames/bugwars/advice/ErrorMessage.java
@@ -1,0 +1,17 @@
+package net.crusadergames.bugwars.advice;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorMessage {
+    private int statusCode;
+    private Date timestamp;
+    private String message;
+    private String description;
+}

--- a/src/main/java/net/crusadergames/bugwars/controller/AuthController.java
+++ b/src/main/java/net/crusadergames/bugwars/controller/AuthController.java
@@ -3,12 +3,16 @@ package net.crusadergames.bugwars.controller;
 import jakarta.validation.Valid;
 import net.crusadergames.bugwars.dto.request.LoginRequest;
 import net.crusadergames.bugwars.dto.request.SignupRequest;
+import net.crusadergames.bugwars.dto.request.TokenRefreshRequest;
 import net.crusadergames.bugwars.dto.response.JwtResponse;
+import net.crusadergames.bugwars.dto.response.TokenRefreshResponse;
 import net.crusadergames.bugwars.model.auth.User;
 import net.crusadergames.bugwars.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @CrossOrigin
 @RestController
@@ -26,5 +30,16 @@ public class AuthController {
     @PostMapping("/login")
     public JwtResponse authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
         return authService.authenticateUser(loginRequest);
+    }
+
+    @PostMapping("/refresh-token")
+    public TokenRefreshResponse refreshToken(@Valid @RequestBody TokenRefreshRequest request) {
+        return authService.refreshToken(request);
+    }
+
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.OK)
+    public void logout(Principal principal) {
+        authService.logout(principal);
     }
 }

--- a/src/main/java/net/crusadergames/bugwars/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/net/crusadergames/bugwars/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,14 @@
+package net.crusadergames.bugwars.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenRefreshRequest {
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/net/crusadergames/bugwars/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/net/crusadergames/bugwars/dto/response/TokenRefreshResponse.java
@@ -4,14 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class JwtResponse {
+public class TokenRefreshResponse {
     private String accessToken;
     private String refreshToken;
-    private String username;
-    private List<String> roles;
 }

--- a/src/main/java/net/crusadergames/bugwars/exception/TokenRefreshException.java
+++ b/src/main/java/net/crusadergames/bugwars/exception/TokenRefreshException.java
@@ -1,0 +1,14 @@
+package net.crusadergames.bugwars.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class TokenRefreshException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public TokenRefreshException(String token, String message) {
+        super(String.format("Failed for [%s]: %s", token, message));
+    }
+}

--- a/src/main/java/net/crusadergames/bugwars/model/auth/RefreshToken.java
+++ b/src/main/java/net/crusadergames/bugwars/model/auth/RefreshToken.java
@@ -1,0 +1,30 @@
+package net.crusadergames.bugwars.model.auth;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", referencedColumnName = "id")
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+}

--- a/src/main/java/net/crusadergames/bugwars/repository/SampleStringRepository.java
+++ b/src/main/java/net/crusadergames/bugwars/repository/SampleStringRepository.java
@@ -1,4 +1,4 @@
-package net.crusadergames.bugwars.repository.auth;
+package net.crusadergames.bugwars.repository;
 
 import net.crusadergames.bugwars.model.SampleString;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/net/crusadergames/bugwars/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/net/crusadergames/bugwars/repository/auth/RefreshTokenRepository.java
@@ -1,0 +1,19 @@
+package net.crusadergames.bugwars.repository.auth;
+
+import net.crusadergames.bugwars.model.auth.RefreshToken;
+import net.crusadergames.bugwars.model.auth.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+
+    Optional<RefreshToken> findByUser(User user);
+
+    @Modifying
+    int deleteByUser(User user);
+}

--- a/src/main/java/net/crusadergames/bugwars/security/jwt/JwtUtils.java
+++ b/src/main/java/net/crusadergames/bugwars/security/jwt/JwtUtils.java
@@ -27,16 +27,20 @@ public class JwtUtils {
 
         UserDetailsImpl userPrincipal = (UserDetailsImpl) authentication.getPrincipal();
 
-        return Jwts.builder()
-                .setSubject((userPrincipal.getUsername()))
-                .setIssuedAt(new Date())
-                .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
-                .signWith(key(), SignatureAlgorithm.HS256)
-                .compact();
+        return generateTokenFromUsername(userPrincipal.getUsername());
     }
 
     private Key key() {
         return Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret));
+    }
+
+    public String generateTokenFromUsername(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date((new Date()).getTime() + jwtExpirationMs))
+                .signWith(key(), SignatureAlgorithm.HS256)
+                .compact();
     }
 
     public String getUserNameFromJwtToken(String token) {

--- a/src/main/java/net/crusadergames/bugwars/security/service/RefreshTokenService.java
+++ b/src/main/java/net/crusadergames/bugwars/security/service/RefreshTokenService.java
@@ -1,0 +1,63 @@
+package net.crusadergames.bugwars.security.service;
+
+import net.crusadergames.bugwars.exception.TokenRefreshException;
+import net.crusadergames.bugwars.model.auth.RefreshToken;
+import net.crusadergames.bugwars.model.auth.User;
+import net.crusadergames.bugwars.repository.auth.RefreshTokenRepository;
+import net.crusadergames.bugwars.repository.auth.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class RefreshTokenService {
+    @Value("${jwtRefreshExpirationMs}")
+    private Long refreshTokenDurationMs;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    public RefreshToken createRefreshToken(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        Optional<RefreshToken> optToken = refreshTokenRepository.findByUser(user);
+        if (optToken.isPresent()) return optToken.get();
+
+        RefreshToken refreshToken = new RefreshToken();
+
+        refreshToken.setUser(userRepository.findById(userId).get());
+        refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs));
+        refreshToken.setToken(UUID.randomUUID().toString());
+
+        refreshToken = refreshTokenRepository.save(refreshToken);
+        return refreshToken;
+    }
+
+    public RefreshToken verifyExpiration(RefreshToken token) {
+        if (token.getExpiryDate().compareTo(Instant.now()) < 0) {
+            refreshTokenRepository.delete(token);
+            throw new TokenRefreshException(token.getToken(), "Refresh token was expired. Please make a new signin request");
+        }
+
+        return token;
+    }
+
+    @Transactional
+    public int deleteByUserId(Long userId) {
+        return refreshTokenRepository.deleteByUser(userRepository.findById(userId).get());
+    }
+}

--- a/src/main/java/net/crusadergames/bugwars/service/AuthService.java
+++ b/src/main/java/net/crusadergames/bugwars/service/AuthService.java
@@ -15,6 +15,8 @@ import net.crusadergames.bugwars.repository.auth.UserRepository;
 import net.crusadergames.bugwars.security.jwt.JwtUtils;
 import net.crusadergames.bugwars.security.service.RefreshTokenService;
 import net.crusadergames.bugwars.security.service.UserDetailsImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -34,6 +36,8 @@ import java.util.stream.Collectors;
 
 @Service
 public class AuthService {
+    private static final Logger logger = LoggerFactory.getLogger(JwtUtils.class);
+
     @Autowired
     RefreshTokenService refreshTokenService;
     @Autowired
@@ -92,6 +96,9 @@ public class AuthService {
         refreshTokenService.verifyExpiration(refreshToken);
         User user = refreshToken.getUser();
         String token = jwtUtils.generateTokenFromUsername(user.getUsername());
+
+        logger.info("Token refreshed");
+
         return new TokenRefreshResponse(token, requestRefreshToken);
     }
 

--- a/src/main/java/net/crusadergames/bugwars/service/AuthService.java
+++ b/src/main/java/net/crusadergames/bugwars/service/AuthService.java
@@ -2,13 +2,18 @@ package net.crusadergames.bugwars.service;
 
 import net.crusadergames.bugwars.dto.request.LoginRequest;
 import net.crusadergames.bugwars.dto.request.SignupRequest;
+import net.crusadergames.bugwars.dto.request.TokenRefreshRequest;
 import net.crusadergames.bugwars.dto.response.JwtResponse;
+import net.crusadergames.bugwars.dto.response.TokenRefreshResponse;
+import net.crusadergames.bugwars.exception.TokenRefreshException;
 import net.crusadergames.bugwars.model.auth.ERole;
+import net.crusadergames.bugwars.model.auth.RefreshToken;
 import net.crusadergames.bugwars.model.auth.Role;
 import net.crusadergames.bugwars.model.auth.User;
 import net.crusadergames.bugwars.repository.auth.RoleRepository;
 import net.crusadergames.bugwars.repository.auth.UserRepository;
 import net.crusadergames.bugwars.security.jwt.JwtUtils;
+import net.crusadergames.bugwars.security.service.RefreshTokenService;
 import net.crusadergames.bugwars.security.service.UserDetailsImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -21,6 +26,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -29,17 +35,15 @@ import java.util.stream.Collectors;
 @Service
 public class AuthService {
     @Autowired
+    RefreshTokenService refreshTokenService;
+    @Autowired
     private UserRepository userRepository;
-
     @Autowired
     private RoleRepository roleRepository;
-
     @Autowired
     private PasswordEncoder passwordEncoder;
-
     @Autowired
     private AuthenticationManager authenticationManager;
-
     @Autowired
     private JwtUtils jwtUtils;
 
@@ -75,6 +79,26 @@ public class AuthService {
         List<String> roles = userDetails.getAuthorities().stream().map(GrantedAuthority::getAuthority)
                 .collect(Collectors.toList());
 
-        return new JwtResponse(jwt, userDetails.getUsername(), roles);
+        RefreshToken refreshToken = refreshTokenService.createRefreshToken(userDetails.getId());
+
+        return new JwtResponse(jwt, refreshToken.getToken(), userDetails.getUsername(), roles);
+    }
+
+    public TokenRefreshResponse refreshToken(TokenRefreshRequest request) {
+        String requestRefreshToken = request.getRefreshToken();
+
+        RefreshToken refreshToken = refreshTokenService.findByToken(requestRefreshToken).orElseThrow(() -> new TokenRefreshException(requestRefreshToken,
+                "Refresh token is not in database!"));
+        refreshTokenService.verifyExpiration(refreshToken);
+        User user = refreshToken.getUser();
+        String token = jwtUtils.generateTokenFromUsername(user.getUsername());
+        return new TokenRefreshResponse(token, requestRefreshToken);
+    }
+
+    public void logout(Principal principal) {
+        if (principal == null) return;
+
+        User user = userRepository.findByUsername(principal.getName()).orElseThrow(() -> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR));
+        refreshTokenService.deleteByUserId(user.getId());
     }
 }

--- a/src/main/java/net/crusadergames/bugwars/service/SampleStringService.java
+++ b/src/main/java/net/crusadergames/bugwars/service/SampleStringService.java
@@ -1,7 +1,7 @@
 package net.crusadergames.bugwars.service;
 
 import net.crusadergames.bugwars.model.SampleString;
-import net.crusadergames.bugwars.repository.auth.SampleStringRepository;
+import net.crusadergames.bugwars.repository.SampleStringRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,4 @@ server.error.include-stacktrace=never
 
 jwtSecret=${JWT_SECRET:VklZbHQ8NTBWJUklIyZwITpfPFIjPiRtYFpIJTB0InEvXE5+eTgsJjxISFVgPnEy}
 jwtExpirationMs=${JWT_EXPIRATION_MS:600000}
+jwtRefreshExpirationMs=${JWT_REFRESH_EXPIRATION_MS:86400000}

--- a/src/test/java/net/crusadergames/bugwars/controller/AuthControllerTests.java
+++ b/src/test/java/net/crusadergames/bugwars/controller/AuthControllerTests.java
@@ -3,7 +3,9 @@ package net.crusadergames.bugwars.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.crusadergames.bugwars.dto.request.LoginRequest;
 import net.crusadergames.bugwars.dto.request.SignupRequest;
+import net.crusadergames.bugwars.dto.request.TokenRefreshRequest;
 import net.crusadergames.bugwars.dto.response.JwtResponse;
+import net.crusadergames.bugwars.dto.response.TokenRefreshResponse;
 import net.crusadergames.bugwars.model.auth.User;
 import net.crusadergames.bugwars.service.AuthService;
 import org.hamcrest.CoreMatchers;
@@ -66,5 +68,26 @@ public class AuthControllerTests {
         response.andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.accessToken", CoreMatchers.is("accessToken")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.refreshToken", CoreMatchers.is("refreshToken")));
+    }
+
+    @Test
+    public void refreshToken_returnsTokenRefreshResponse() throws Exception {
+        TokenRefreshRequest refreshRequest = new TokenRefreshRequest("refreshToken");
+        TokenRefreshResponse refreshResponse = new TokenRefreshResponse("accessToken", "refreshToken");
+        when(authService.refreshToken(ArgumentMatchers.any())).thenReturn(refreshResponse);
+
+        ResultActions response = mockMvc.perform(post("/api/auth/refresh-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(refreshRequest)));
+
+        response.andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.accessToken", CoreMatchers.is("accessToken")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.refreshToken", CoreMatchers.is("refreshToken")));
+    }
+
+    @Test
+    public void logout_returnsOkStatus() throws Exception {
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
 }

--- a/src/test/java/net/crusadergames/bugwars/controller/AuthControllerTests.java
+++ b/src/test/java/net/crusadergames/bugwars/controller/AuthControllerTests.java
@@ -56,7 +56,7 @@ public class AuthControllerTests {
     @Test
     public void authenticateUser_returnsJwtResponse() throws Exception {
         LoginRequest loginRequest = new LoginRequest("test_user", "password111");
-        JwtResponse jwtResponse = new JwtResponse("token", "user", List.of("ROLE_USER"));
+        JwtResponse jwtResponse = new JwtResponse("accessToken", "refreshToken", "user", List.of("ROLE_USER"));
         when(authService.authenticateUser(ArgumentMatchers.any())).thenReturn(jwtResponse);
 
         ResultActions response = mockMvc.perform(post("/api/auth/login")
@@ -64,6 +64,7 @@ public class AuthControllerTests {
                 .content(objectMapper.writeValueAsString(loginRequest)));
 
         response.andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.token", CoreMatchers.is("token")));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.accessToken", CoreMatchers.is("accessToken")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.refreshToken", CoreMatchers.is("refreshToken")));
     }
 }

--- a/src/test/java/net/crusadergames/bugwars/service/SampleServiceTests.java
+++ b/src/test/java/net/crusadergames/bugwars/service/SampleServiceTests.java
@@ -1,7 +1,7 @@
 package net.crusadergames.bugwars.service;
 
 import net.crusadergames.bugwars.model.SampleString;
-import net.crusadergames.bugwars.repository.auth.SampleStringRepository;
+import net.crusadergames.bugwars.repository.SampleStringRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
Implemented token refreshing. Also added logout endpoint.

Unlike an accessToken, the server stores a refreshToken in a database so it can revoke them at any time if necessary. Logout will remove the token from the server.
